### PR TITLE
Fixes: 'StyleShotNode' object has no attribute 'styleshot'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 jmespath
 python-dateutil
 diffusers
-transformers
+transformers>=4.42.3 # see https://github.com/open-mmlab/StyleShot/issues/11#issuecomment-2217858617
 accelerate
 opencv-python
 einops


### PR DESCRIPTION
This fixes a problem when because of an incompatible version of the transformers package, the model does not load properly, prints a long warning to the comfyui.log, prints an error box in the web UI, and the execution halts.

This patch sets a known-good version as the minimum version in requirements.txt (the version could possibly be set lower; the upstream authors have tested this version, and so have I).

For people who face this problem, updating in the ComfyUI Manager will fix the issue.


Set minimum version for the `transformers` dependency in requirements.txt

See https://github.com/open-mmlab/StyleShot/issues/11#issuecomment-2217858617